### PR TITLE
Logger naming

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -3,10 +3,12 @@ package backend
 import "github.com/urso/ecslog/ctxtree"
 
 type Backend interface {
+	For(name string) Backend
+
 	IsEnabled(lvl Level) bool
 	UseContext() bool
 
-	Log(lvl Level, caller Caller, msg string, ctx ctxtree.Ctx, causes []error)
+	Log(name string, lvl Level, caller Caller, msg string, ctx ctxtree.Ctx, causes []error)
 }
 
 type Level uint8

--- a/backend/structlog/structlog.go
+++ b/backend/structlog/structlog.go
@@ -82,10 +82,12 @@ func (l *Logger) reset() {
 	l.types, _ = gotype.NewIterator(unfolder, l.typeOpts...)
 }
 
+func (l *Logger) For(name string) backend.Backend  { return l }
 func (l *Logger) IsEnabled(lvl backend.Level) bool { return l.out.Enabled(lvl) }
 func (l *Logger) UseContext() bool                 { return true }
 
 func (l *Logger) Log(
+	name string,
 	lvl backend.Level,
 	caller backend.Caller,
 	msg string, fields ctxtree.Ctx,
@@ -110,6 +112,9 @@ func (l *Logger) Log(
 
 		ecs.Message(msg),
 	})
+	if name != "" {
+		ctx.AddField(ecs.Log.Name(name))
+	}
 
 	if userCtx.Len() > 0 {
 		ctx.AddField(fld.Any("fields", &userCtx))

--- a/fld/ecs/extra.go
+++ b/fld/ecs/extra.go
@@ -8,6 +8,7 @@ func Tags(tags ...string) fld.Field { return ecsAny("tags", tags) }
 
 func Labels(labels map[string]string) fld.Field { return ecsAny("labels", labels) }
 
+func (nsLog) Name(name string) fld.Field      { return ecsString("log.name", name) }
 func (nsLog) FilePath(s string) fld.Field     { return ecsString("log.file.path", s) }
 func (nsLog) FileLine(i int) fld.Field        { return ecsInt("log.file.line", i) }
 func (nsLog) FileBasename(s string) fld.Field { return ecsString("log.file.basename", s) }


### PR DESCRIPTION
add support to create Named loggers. Backend has option to derive
alternative backend if a named logger is generated from a logger.