### PR TITLE
Introduce non-formatting log methods

### DIFF
--- a/log_bench_test.go
+++ b/log_bench_test.go
@@ -1,0 +1,79 @@
+package ecslog
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/urso/ecslog/backend"
+	"github.com/urso/ecslog/ctxtree"
+)
+
+type benchBackend struct {
+	Disabled bool
+	Context  bool
+}
+
+func BenchmarkPureMessage(b *testing.B) {
+	messages := []string{
+		makeASCIIMessage(5),
+		makeASCIIMessage(20),
+		makeASCIIMessage(100),
+		makeASCIIMessage(1000),
+	}
+
+	for _, msg := range messages {
+		msg := msg
+		b.Run(fmt.Sprintf("msg=%v", len(msg)), func(b *testing.B) {
+			for _, withContext := range []bool{false, true} {
+				b.Run(fmt.Sprintf("context=%v", withContext), func(b *testing.B) {
+					testBackend := &benchBackend{Context: withContext}
+					logger := New(testBackend)
+
+					b.Run("log", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							logger.Info(msg)
+						}
+					})
+
+					b.Run("logf", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							logger.Infof(msg)
+						}
+					})
+				})
+			}
+		})
+	}
+}
+
+func makeASCIIMessage(len int) string {
+	gen := rngASCIIString(rngIntConst(len))
+	return gen(rand.New(rand.NewSource(0)))
+}
+
+func rngIntRange(min, max int) func(*rand.Rand) int {
+	return func(rng *rand.Rand) int {
+		return rand.Intn(max-min) + min
+	}
+}
+
+func rngIntConst(i int) func(*rand.Rand) int {
+	return func(_ *rand.Rand) int { return i }
+}
+
+func rngASCIIString(len func(*rand.Rand) int) func(*rand.Rand) string {
+	return func(rng *rand.Rand) string {
+		L := len(rng)
+		buf := make([]byte, L)
+		for i := range buf {
+			buf[i] = byte(rand.Intn('Z'-'0') + '0')
+		}
+		return string(buf)
+	}
+}
+
+func (bb *benchBackend) For(_ string) backend.Backend                                                { return bb }
+func (bb *benchBackend) IsEnabled(_ backend.Level) bool                                              { return !bb.Disabled }
+func (bb *benchBackend) UseContext() bool                                                            { return bb.Context }
+func (bb *benchBackend) Log(_ string, _ Level, _ backend.Caller, _ string, _ ctxtree.Ctx, _ []error) {}


### PR DESCRIPTION
- Add simple benchmarks comparing formatting and non-formatting loggers
- reduce memory allocation by help escape analyzer
- introduce Trace(f), Debug(f), Info(f), Error(f)

Benchmark Results:

```
benchmark                                              old ns/op     new ns/op     delta
BenchmarkPureMessage/msg=5/context=false/log-4         647           646           -0.15%
BenchmarkPureMessage/msg=5/context=false/logf-4        837           742           -11.35%
BenchmarkPureMessage/msg=5/context=true/log-4          673           682           +1.34%
BenchmarkPureMessage/msg=5/context=true/logf-4         886           720           -18.74%
BenchmarkPureMessage/msg=20/context=false/log-4        644           645           +0.16%
BenchmarkPureMessage/msg=20/context=false/logf-4       848           747           -11.91%
BenchmarkPureMessage/msg=20/context=true/log-4         671           700           +4.32%
BenchmarkPureMessage/msg=20/context=true/logf-4        891           730           -18.07%
BenchmarkPureMessage/msg=100/context=false/log-4       645           642           -0.47%
BenchmarkPureMessage/msg=100/context=false/logf-4      905           804           -11.16%
BenchmarkPureMessage/msg=100/context=true/log-4        673           684           +1.63%
BenchmarkPureMessage/msg=100/context=true/logf-4       954           789           -17.30%
BenchmarkPureMessage/msg=1000/context=false/log-4      646           650           +0.62%
BenchmarkPureMessage/msg=1000/context=false/logf-4     1314          1205          -8.30%
BenchmarkPureMessage/msg=1000/context=true/log-4       673           695           +3.27%
BenchmarkPureMessage/msg=1000/context=true/logf-4      1352          1216          -10.06%

benchmark                                              old allocs     new allocs     delta
BenchmarkPureMessage/msg=5/context=false/log-4         1              1              +0.00%
BenchmarkPureMessage/msg=5/context=false/logf-4        2              0              -100.00%
BenchmarkPureMessage/msg=5/context=true/log-4          1              1              +0.00%
BenchmarkPureMessage/msg=5/context=true/logf-4         3              0              -100.00%
BenchmarkPureMessage/msg=20/context=false/log-4        1              1              +0.00%
BenchmarkPureMessage/msg=20/context=false/logf-4       2              0              -100.00%
BenchmarkPureMessage/msg=20/context=true/log-4         1              1              +0.00%
BenchmarkPureMessage/msg=20/context=true/logf-4        3              0              -100.00%
BenchmarkPureMessage/msg=100/context=false/log-4       1              1              +0.00%
BenchmarkPureMessage/msg=100/context=false/logf-4      2              0              -100.00%
BenchmarkPureMessage/msg=100/context=true/log-4        1              1              +0.00%
BenchmarkPureMessage/msg=100/context=true/logf-4       3              0              -100.00%
BenchmarkPureMessage/msg=1000/context=false/log-4      1              1              +0.00%
BenchmarkPureMessage/msg=1000/context=false/logf-4     2              0              -100.00%
BenchmarkPureMessage/msg=1000/context=true/log-4       1              1              +0.00%
BenchmarkPureMessage/msg=1000/context=true/logf-4      3              0              -100.00%
```