### PR TITLE
infinite loop issues when parsing formating flags

### DIFF
--- a/fld/fldfmt.go
+++ b/fld/fldfmt.go
@@ -1303,27 +1303,27 @@ func parseField(st *state, msg string, start, end int) (i int, err error) {
 	return i + 1, nil
 }
 
-func parseFlag(st *state, msg string, pos int) (i int, isflag bool) {
+func parseFlag(st *state, msg string, pos int) (int, bool) {
 	switch msg[pos] {
 	case '#':
 		st.flags.sharp = true
-		return i + 1, true
+		return pos + 1, true
 	case '+':
 		st.flags.plus = true
-		return i + 1, true
+		return pos + 1, true
 	case '-':
 		st.flags.minus = true
 		st.flags.zero = false
-		return i + 1, true
+		return pos + 1, true
 	case '0':
 		st.flags.zero = !st.flags.minus
-		return i + 1, true
+		return pos + 1, true
 	case ' ':
 		st.flags.space = true
-		return i + 1, true
+		return pos + 1, true
 	}
 
-	return i, false
+	return 0, false
 }
 
 func parseNum(msg string, start, end int) (num int, isnum bool, i int) {

--- a/fld/fldfmt_test.go
+++ b/fld/fldfmt_test.go
@@ -1,0 +1,75 @@
+package fld
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFlags(t *testing.T) {
+	testCases := map[string]struct {
+		s         string
+		startPos  int
+		expPos    int
+		provState *state
+		expState  *state
+		expMatch  bool
+	}{
+		"sharp (#)": {
+			s:        "#",
+			expPos:   1,
+			expState: &state{flags: flags{sharp: true}},
+			expMatch: true,
+		},
+		"plus (+)": {
+			s:        "+",
+			expPos:   1,
+			expState: &state{flags: flags{plus: true}},
+			expMatch: true,
+		},
+		"minus (-)": {
+			s:        "-",
+			expPos:   1,
+			expState: &state{flags: flags{minus: true, zero: false}},
+			expMatch: true,
+		},
+		"zero (0) when minutes is set to true": {
+			s:         "0",
+			expPos:    1,
+			provState: &state{flags: flags{minus: true}},
+			expState:  &state{flags: flags{minus: true, zero: false}},
+			expMatch:  true,
+		},
+		"zero (0) when minutes is set to false": {
+			s:         "0",
+			expPos:    1,
+			provState: &state{flags: flags{minus: false}},
+			expState:  &state{flags: flags{minus: true, zero: true}},
+			expMatch:  true,
+		},
+		"space (' ')": {
+			s:        " ",
+			expPos:   1,
+			expState: &state{flags: flags{space: true}},
+			expMatch: true,
+		},
+		"no match": {
+			s:        "A",
+			expPos:   0,
+			expState: &state{flags: flags{}},
+			expMatch: false,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if test.provState == nil {
+				test.provState = &state{flags: flags{}}
+			}
+
+			pos, match := parseFlag(test.provState, test.s, test.startPos)
+			require.Equal(t, test.expPos, pos)
+			require.Equal(t, test.expMatch, match)
+		})
+	}
+}


### PR DESCRIPTION
When the parseFlags was invoked on string that contains a +, the parsing
code was entering into an infinite and would keep writing the same
string to the buffer until all the memory was consumed.